### PR TITLE
Add schema file loading for bulk insert

### DIFF
--- a/config/reports_config.json
+++ b/config/reports_config.json
@@ -1,32 +1,40 @@
 {
 	"reports": [
-		{
-			"report_name": "report1",
-			"connection_string": "DB1_CONNECTION_STRING",
-			"proc_name": "proc_db1",
-			"params": ["param1", "param2"],
-			"is_proc": true
-		},
-		{
-			"report_name": "report2",
-			"connection_string": "DB2_CONNECTION_STRING",
-			"proc_name": "proc_db2",
-			"params": ["param1"],
-			"is_proc": true
-		},
-		{
-			"report_name": "report3",
-			"connection_string": "DB3_CONNECTION_STRING",
-			"query_file": "queries/db3_query.sql",
-			"params": ["param2"],
-			"is_proc": false
-		},
-		{
-			"report_name": "report4",
-			"connection_string": "EXCEL_REPORT_CONNECTION_STRING",
-			"file_path": "C:/path/to/excel_report.xlsx",
-			"is_proc": false,
-			"is_excel": true
-		}
-	]
+                {
+                        "report_name": "report1",
+                        "connection_string": "DB1_CONNECTION_STRING",
+                        "proc_name": "proc_db1",
+                        "params": ["param1", "param2"],
+                        "is_proc": true,
+                        "schema_file": "schemas/report1_schema.json",
+                        "rename_map": {"old_id": "id"}
+                },
+                {
+                        "report_name": "report2",
+                        "connection_string": "DB2_CONNECTION_STRING",
+                        "proc_name": "proc_db2",
+                        "params": ["param1"],
+                        "is_proc": true,
+                        "schema_file": "schemas/report2_schema.json",
+                        "rename_map": {}
+                },
+                {
+                        "report_name": "report3",
+                        "connection_string": "DB3_CONNECTION_STRING",
+                        "query_file": "queries/db3_query.sql",
+                        "params": ["param2"],
+                        "is_proc": false,
+                        "schema_file": "schemas/report3_schema.json",
+                        "rename_map": {}
+                },
+                {
+                        "report_name": "report4",
+                        "connection_string": "EXCEL_REPORT_CONNECTION_STRING",
+                        "file_path": "C:/path/to/excel_report.xlsx",
+                        "is_proc": false,
+                        "is_excel": true,
+                        "schema_file": "schemas/report4_schema.json",
+                        "rename_map": {}
+                }
+        ]
 }

--- a/config/schemas/report1_schema.json
+++ b/config/schemas/report1_schema.json
@@ -1,0 +1,1 @@
+{"id": "int", "value": "str"}

--- a/config/schemas/report2_schema.json
+++ b/config/schemas/report2_schema.json
@@ -1,0 +1,1 @@
+{"id": "int", "value": "str"}

--- a/config/schemas/report3_schema.json
+++ b/config/schemas/report3_schema.json
@@ -1,0 +1,1 @@
+{"id": "int", "value": "str"}

--- a/config/schemas/report4_schema.json
+++ b/config/schemas/report4_schema.json
@@ -1,0 +1,1 @@
+{"id": "int", "value": "str"}

--- a/core/db/push.py
+++ b/core/db/push.py
@@ -1,0 +1,69 @@
+from typing import Dict, List, Optional, Type
+
+import pandas as pd
+import pyodbc
+
+from utils.utils import load_schema
+
+
+def validate_dataframe_schema(df: pd.DataFrame, schema: Dict[str, Type]) -> None:
+    """Validate DataFrame columns and dtypes against expected schema."""
+    for col, col_type in schema.items():
+        if col not in df.columns:
+            raise ValueError(f"Missing required column: {col}")
+        # allow NaN values but check non-null values for type
+        non_null = df[col].dropna()
+        if not non_null.empty and not non_null.map(lambda x: isinstance(x, col_type)).all():
+            raise ValueError(f"Column {col} has incorrect type")
+
+
+def bulk_insert_dataframe(
+    conn_str: str,
+    table_name: str,
+    df: pd.DataFrame,
+    columns: Optional[List[str]] = None,
+    expected_schema: Optional[Dict[str, Type]] = None,
+    schema_file: Optional[str] = None,
+    rename_map: Optional[Dict[str, str]] = None,
+) -> None:
+    """Insert a pandas DataFrame into a SQL Server table using ``fast_executemany``.
+
+    Args:
+        conn_str: ODBC connection string for SQL Server.
+        table_name: Name of the destination table.
+        df: Data to insert.
+        columns: Optional subset of columns from ``df`` to insert.
+        expected_schema: Dictionary defining expected column names and Python
+            datatypes. Data is validated against this schema before insertion.
+        schema_file: Path to a JSON file containing the expected schema. This is
+            mutually exclusive with ``expected_schema``.
+        rename_map: Mapping of existing column names to the names expected in the
+            destination table.
+    """
+    if rename_map is not None:
+        df = df.rename(columns=rename_map)
+        if columns is not None:
+            columns = [rename_map.get(col, col) for col in columns]
+
+    if columns is None:
+        columns = df.columns.tolist()
+
+    if schema_file is not None:
+        if expected_schema is not None:
+            raise ValueError("Provide either expected_schema or schema_file, not both")
+        expected_schema = load_schema(schema_file)
+
+    if expected_schema is not None:
+        validate_dataframe_schema(df, expected_schema)
+
+    placeholders = ",".join(["?"] * len(columns))
+    column_names = ",".join(columns)
+    insert_sql = f"INSERT INTO {table_name} ({column_names}) VALUES ({placeholders})"
+
+    data = [tuple(row) for row in df[columns].itertuples(index=False, name=None)]
+
+    with pyodbc.connect(conn_str) as conn:  # type: ignore # pyodbc.Connection
+        cursor = conn.cursor()  # type: ignore # pyodbc.Cursor
+        cursor.fast_executemany = True
+        cursor.executemany(insert_sql, data)
+        conn.commit()

--- a/core/db/push.py
+++ b/core/db/push.py
@@ -49,9 +49,17 @@ def bulk_insert_dataframe(
         columns = df.columns.tolist()
 
     if schema_file is not None:
+        import os
+        import json
+
         if expected_schema is not None:
             raise ValueError("Provide either expected_schema or schema_file, not both")
-        expected_schema = load_schema(schema_file)
+        if not os.path.isfile(schema_file):
+            raise FileNotFoundError(f"Schema file '{schema_file}' does not exist.")
+        try:
+            expected_schema = load_schema(schema_file)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to decode JSON from schema file '{schema_file}': {e}")
 
     if expected_schema is not None:
         validate_dataframe_schema(df, expected_schema)

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,0 +1,115 @@
+import pandas as pd
+import pyodbc
+import pytest
+
+from core.db.push import bulk_insert_dataframe
+
+
+class DummyCursor:
+    def __init__(self) -> None:
+        self.fast_executemany = False
+        self.executed_sql = None
+        self.executed_params = None
+
+    def executemany(self, sql, params):
+        self.executed_sql = sql
+        self.executed_params = params
+
+
+class DummyConnection:
+    def __init__(self) -> None:
+        self.cursor_obj = DummyCursor()
+        self.committed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_bulk_insert_dataframe(monkeypatch):
+    dummy_conn = DummyConnection()
+    
+    def fake_connect(conn_str):
+        assert conn_str == "CONN_STR"
+        return dummy_conn
+
+    monkeypatch.setattr(pyodbc, "connect", fake_connect)
+
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    schema = {"id": int, "value": str}
+    bulk_insert_dataframe("CONN_STR", "dbo.test", df, expected_schema=schema)
+
+    assert dummy_conn.cursor_obj.fast_executemany is True
+    expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
+    assert dummy_conn.cursor_obj.executed_sql == expected_sql
+    assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+    assert dummy_conn.committed is True
+
+
+def test_bulk_insert_dataframe_schema_validation(monkeypatch):
+    dummy_conn = DummyConnection()
+
+    def fake_connect(conn_str):
+        return dummy_conn
+
+    monkeypatch.setattr(pyodbc, "connect", fake_connect)
+
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", 2]})
+    schema = {"id": int, "value": str}
+    with pytest.raises(ValueError):
+        bulk_insert_dataframe("CONN_STR", "dbo.test", df, expected_schema=schema)
+
+
+def test_bulk_insert_dataframe_schema_file(monkeypatch, tmp_path):
+    dummy_conn = DummyConnection()
+
+    def fake_connect(conn_str):
+        return dummy_conn
+
+    monkeypatch.setattr(pyodbc, "connect", fake_connect)
+
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text('{"id": "int", "value": "str"}')
+
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    bulk_insert_dataframe("CONN_STR", "dbo.test", df, schema_file=str(schema_path))
+
+    assert dummy_conn.cursor_obj.fast_executemany is True
+    expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
+    assert dummy_conn.cursor_obj.executed_sql == expected_sql
+    assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+    assert dummy_conn.committed is True
+
+
+def test_bulk_insert_dataframe_rename(monkeypatch):
+    dummy_conn = DummyConnection()
+
+    def fake_connect(conn_str):
+        return dummy_conn
+
+    monkeypatch.setattr(pyodbc, "connect", fake_connect)
+
+    df = pd.DataFrame({"old_id": [1, 2], "old_value": ["a", "b"]})
+    rename_map = {"old_id": "id", "old_value": "value"}
+    schema = {"id": int, "value": str}
+
+    bulk_insert_dataframe(
+        "CONN_STR",
+        "dbo.test",
+        df,
+        expected_schema=schema,
+        rename_map=rename_map,
+    )
+
+    expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
+    assert dummy_conn.cursor_obj.executed_sql == expected_sql
+    assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -64,8 +64,10 @@ def test_bulk_insert_dataframe_schema_validation(monkeypatch):
 
     df = pd.DataFrame({"id": [1, 2], "value": ["a", 2]})
     schema = {"id": int, "value": str}
-    with pytest.raises(ValueError):
+    
+    with pytest.raises(ValueError, match="Column 'value' expected type str"):
         bulk_insert_dataframe("CONN_STR", "dbo.test", df, expected_schema=schema)
+
 
 
 def test_bulk_insert_dataframe_schema_file(monkeypatch, tmp_path):

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -113,3 +113,61 @@ def test_bulk_insert_dataframe_rename(monkeypatch):
     assert dummy_conn.cursor_obj.executed_sql == expected_sql
     assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
 
+
+def test_bulk_insert_dataframe_partial_rename(monkeypatch):
+    dummy_conn = DummyConnection()
+
+    def fake_connect(conn_str):
+        return dummy_conn
+
+    monkeypatch.setattr(pyodbc, "connect", fake_connect)
+
+    # Only one column is renamed, the other is left as-is
+    df = pd.DataFrame({"id": [1, 2], "old_value": ["a", "b"]})
+    rename_map = {"old_value": "value"}
+    schema = {"id": int, "value": str}
+
+    bulk_insert_dataframe(
+        "CONN_STR",
+        "dbo.test",
+        df,
+        expected_schema=schema,
+        rename_map=rename_map,
+    )
+
+    expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
+    assert dummy_conn.cursor_obj.executed_sql == expected_sql
+    assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+
+
+def test_bulk_insert_dataframe_columns_and_rename(monkeypatch):
+    dummy_conn = DummyConnection()
+
+    def fake_connect(conn_str):
+        return dummy_conn
+
+    monkeypatch.setattr(pyodbc, "connect", fake_connect)
+
+    # DataFrame has extra columns, only a subset is inserted, and one is renamed
+    df = pd.DataFrame({
+        "id": [1, 2],
+        "old_value": ["a", "b"],
+        "extra": [100, 200],
+    })
+    rename_map = {"old_value": "value"}
+    schema = {"id": int, "value": str}
+    columns = ["id", "old_value"]  # Only insert these columns, with renaming
+
+    bulk_insert_dataframe(
+        "CONN_STR",
+        "dbo.test",
+        df,
+        expected_schema=schema,
+        columns=columns,
+        rename_map=rename_map,
+    )
+
+    expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
+    assert dummy_conn.cursor_obj.executed_sql == expected_sql
+    assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict, Type
 
 
 def load_config(config_file: str) -> dict:
@@ -11,3 +12,17 @@ def read_sql_query(query_file: str) -> str:
     """Reads an SQL query from a .sql file."""
     with open(query_file, "r") as file:
         return file.read()
+
+
+PYTHON_TYPE_MAP: dict[str, Type] = {
+    "int": int,
+    "float": float,
+    "str": str,
+    "bool": bool,
+}
+
+
+def load_schema(schema_file: str) -> Dict[str, Type]:
+    """Load a JSON schema file and convert type strings to Python types."""
+    raw_schema = load_config(schema_file)
+    return {col: PYTHON_TYPE_MAP[type_str] for col, type_str in raw_schema.items()}


### PR DESCRIPTION
## Summary
- move large DataFrame schemas into dedicated JSON files
- expose `schema_file` argument in `bulk_insert_dataframe`
- add helper to load schema files
- extend tests to cover loading schema from file
- allow renaming columns during bulk insert using `rename_map`

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError for dotenv)*


------
https://chatgpt.com/codex/tasks/task_b_686049af597c832e8b104e0a134cc8a0

## Summary by Sourcery

Implement JSON schema file loading and column renaming in the bulk insert utility, including schema validation and corresponding helper functions.

New Features:
- Add schema_file parameter to bulk_insert_dataframe to load JSON schemas
- Support renaming DataFrame columns via rename_map during bulk insert

Enhancements:
- Introduce validate_dataframe_schema to enforce DataFrame schema before insertion
- Add load_schema helper with type string-to-Python mapping in utils

Tests:
- Add tests for schema file loading, schema validation, and column renaming

Chores:
- Add placeholder JSON schema files under config/schemas