### PR TITLE
Fix env loading fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ DB_COL06=DRIVER='{ODBC Driver 17 for SQL Server};SERVER=sql_col06;DATABASE=TnT_v
 DB_COL07=DRIVER='{ODBC Driver 17 for SQL Server};SERVER=sql_col07;DATABASE=TnT_v1;UID=sql_admin;PWD=change_me;unicode_results=True'
 DB_COL10=DRIVER='{ODBC Driver 17 for SQL Server};SERVER=sql_col10;DATABASE=TnT_v1;UID=sql_admin;PWD=change_me;unicode_results=True'
 DB_DW_REPORTING=DRIVER='{ODBC Driver 17 for SQL Server};SERVER=sql_instance;DATABASE=Reporting;UID=sql_admin;PWD=change_me2020;unicode_results=True'
+
+# Values used in tests
+TEST_IMPORTS=True
+TEST_IMPORTS_TEXT=kgk
+TEST_IMPORTS_INT=9

--- a/settings.py
+++ b/settings.py
@@ -4,10 +4,17 @@ import sys
 from dotenv import load_dotenv
 
 # Load environment variables
-if "prod" in [arg.lower() for arg in sys.argv]:
-    load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), ".env.prod"))
-else:
-    load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), ".env.uat"))
+_args = [arg.lower() for arg in sys.argv]
+env_file = ".env.prod" if "prod" in _args else ".env.uat"
+env_path = os.path.join(os.path.dirname(__file__), env_file)
+
+# Fallback to the example file if the expected file does not exist
+if not os.path.exists(env_path):
+    env_path = os.path.join(os.path.dirname(__file__), ".env.example")
+
+# Load the environment file if present and also any variables from the
+# environment itself
+load_dotenv(env_path)
 load_dotenv()
 
 ### Imports to make sure dotenv library works as expected


### PR DESCRIPTION
## Summary
- load `.env.example` when environment-specific files aren't present
- add default test values to `.env.example`

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b83ff6b0c83219b806980f25e1685

## Summary by Sourcery

Refactor environment loading in settings.py to choose between .env.prod or .env.uat based on arguments, fall back to .env.example if needed, and update .env.example with default variables for testing

Bug Fixes:
- Fallback to loading .env.example when the specified environment file is missing

Enhancements:
- Refactor settings.py to select the environment file based on command-line arguments and consolidate dotenv loading
- Add default test values to .env.example