### PR TITLE
Add commit checks for rename tests

### DIFF
--- a/helper/db/push.py
+++ b/helper/db/push.py
@@ -21,7 +21,6 @@ def validate_dataframe_schema(
         if (
             not non_null.empty
             and not non_null.map(lambda x: isinstance(x, col_type)).all()
-            and col_type is not str
         ):
             raise ValueError(
                 # f"Column {col} has incorrect type {non_null.map(lambda x: isinstance(x, col_type)).all()}"

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -113,6 +113,7 @@ def test_bulk_insert_dataframe_rename(monkeypatch):
     expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
     assert dummy_conn.cursor_obj.executed_sql == expected_sql
     assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+    assert dummy_conn.committed is True
 
 
 def test_bulk_insert_dataframe_partial_rename(monkeypatch):
@@ -139,6 +140,7 @@ def test_bulk_insert_dataframe_partial_rename(monkeypatch):
     expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
     assert dummy_conn.cursor_obj.executed_sql == expected_sql
     assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+    assert dummy_conn.committed is True
 
 
 def test_bulk_insert_dataframe_columns_and_rename(monkeypatch):
@@ -173,3 +175,4 @@ def test_bulk_insert_dataframe_columns_and_rename(monkeypatch):
     expected_sql = "INSERT INTO dbo.test (id,value) VALUES (?,?)"
     assert dummy_conn.cursor_obj.executed_sql == expected_sql
     assert dummy_conn.cursor_obj.executed_params == [(1, "a"), (2, "b")]
+    assert dummy_conn.committed is True


### PR DESCRIPTION
## Summary
- validate schema columns without skipping `str`
- ensure `bulk_insert_dataframe` commits in rename tests

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688604c7d164832487f4175770010667

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/mavericcspsttel404/022_bfr/2)
<!-- GitContextEnd -->

## Summary by Sourcery

Enforce commit behavior in bulk_insert_dataframe rename tests and enhance dataframe schema validation by validating string types.

Bug Fixes:
- Include string types in dataframe schema validation by removing the exception for str columns

Enhancements:
- Require commit() to be called in bulk_insert_dataframe rename tests

Tests:
- Add assertions to verify dummy connections are committed after bulk inserts in rename tests