### PR TITLE
Fix DeliveryVehicleArrivalByHub logger

### DIFF
--- a/core/reports/DeliveryVehicleArrivalByHub.py
+++ b/core/reports/DeliveryVehicleArrivalByHub.py
@@ -8,7 +8,7 @@ from helper.excel.extract import handle_excel_file
 # from settings import PATH_DVA_BY_HUB_REPORT
 from utils.logger import get_logger
 
-logger = get_logger
+logger = get_logger(__name__)
 
 
 def extract_report_data(config: Dict[str, Any]) -> pd.DataFrame:

--- a/helper/db/push.py
+++ b/helper/db/push.py
@@ -21,7 +21,6 @@ def validate_dataframe_schema(
         if (
             not non_null.empty
             and not non_null.map(lambda x: isinstance(x, col_type)).all()
-            and col_type is not str
         ):
             raise ValueError(
                 # f"Column {col} has incorrect type {non_null.map(lambda x: isinstance(x, col_type)).all()}"


### PR DESCRIPTION
## Summary
- initialize logger in DeliveryVehicleArrivalByHub with module name
- enforce schema validation for string columns

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688604c721c88324b625400c54d828a1

## Summary by Sourcery

Initialize the logger correctly and tighten DataFrame schema validation.

Bug Fixes:
- Initialize logger with module name in DeliveryVehicleArrivalByHub

Enhancements:
- Enforce schema validation by checking types of non-null DataFrame column values